### PR TITLE
DF-28 Activer/désactiver un utilisateur

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -22,12 +22,13 @@ import { AuthInterceptor } from './http-interceptors/authInterceptor';
 
 import { UtilisateurFormComponent } from './components/utilisateur/utilisateur-form.component';
 import { UtilisateurSecuriteComponent } from './components/utilisateur/utilisateur-securite.component';
-import { ConfirmDeleteUtilisateurDialogComponent, UtilisateurListComponent } from './components/utilisateur/utilisateur-list.component';
+import { UtilisateurListComponent } from './components/utilisateur/utilisateur-list.component';
 import { UtilisateurBackendService } from './backendservices/utilisateur.backendservice';
 import { SiteFormComponent } from './components/site/site-form.component';
-import { ConfirmDeleteSiteDialogComponent, SiteListComponent } from './components/site/site-list.component';
+import { SiteListComponent } from './components/site/site-list.component';
 import { SiteBackendService } from './backendservices/site.backendservice';
 import { VehiculeComponent } from './components/vehicule/vehicule.component';
+import { DialogConfirmComponent } from './components/dialog-confirm/dialog-confirm.component';
 
 Sentry.init({ dsn: environment.SENTRY_DSN });
 
@@ -42,12 +43,11 @@ Sentry.init({ dsn: environment.SENTRY_DSN });
     UtilisateurListComponent,
     UtilisateurFormComponent,
     UtilisateurSecuriteComponent,
-    ConfirmDeleteUtilisateurDialogComponent,
     SiteListComponent,
     SiteFormComponent,
-    ConfirmDeleteSiteDialogComponent,
     VehiculeComponent,
-    AlertComponent
+    AlertComponent,
+    DialogConfirmComponent,
   ],
   entryComponents: [],
   imports: [

--- a/frontend/src/app/components/dialog-confirm/dialog-confirm.component.html
+++ b/frontend/src/app/components/dialog-confirm/dialog-confirm.component.html
@@ -1,0 +1,8 @@
+<h1 mat-dialog-title>{{data?.titre}}</h1>
+<mat-dialog-content class="mat-typography">
+  {{data?.libConfirmation}}
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-raised-button color="primary" type="button" [mat-dialog-close]="true" cdkFocusInitial>{{data?.libBouton}}</button>
+  <button mat-raised-button color="accent" type="button" mat-dialog-close>Annuler</button>
+</mat-dialog-actions>

--- a/frontend/src/app/components/dialog-confirm/dialog-confirm.component.ts
+++ b/frontend/src/app/components/dialog-confirm/dialog-confirm.component.ts
@@ -1,0 +1,12 @@
+import { Component, Inject } from "@angular/core";
+import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
+
+@Component({
+  selector: 'confirm-dialog',
+  templateUrl: './dialog-confirm.component.html',
+})
+export class DialogConfirmComponent {
+  constructor(
+    public dialogRef: MatDialogRef<DialogConfirmComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { titre: string, libConfirmation: string, libBouton?: string }) { }
+}

--- a/frontend/src/app/components/site/dialogs/confirm-delete-site-dialog.component.html
+++ b/frontend/src/app/components/site/dialogs/confirm-delete-site-dialog.component.html
@@ -1,8 +1,0 @@
-<h1 mat-dialog-title>Confirmation suppression</h1>
-<mat-dialog-content class="mat-typography">
-  Souhaitez vous supprimer le site  "{{data?.site?.Libelle}}" ?
-</mat-dialog-content>
-<mat-dialog-actions align="end">
-  <button mat-raised-button color="primary" type="button" [mat-dialog-close]="true" cdkFocusInitial>Supprimer</button>
-  <button mat-raised-button color="accent" type="button" mat-dialog-close>Annuler</button>
-</mat-dialog-actions>

--- a/frontend/src/app/components/site/site-list.component.ts
+++ b/frontend/src/app/components/site/site-list.component.ts
@@ -4,6 +4,7 @@ import { Site } from 'src/app/models/site';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
+import { DialogConfirmComponent } from '../dialog-confirm/dialog-confirm.component';
 
 @Component({
   selector: 'site-list',
@@ -48,30 +49,18 @@ export class SiteListComponent implements OnInit {
   }
 
   openConfirmDeleteDialog(site: Site) {
-    const dialogRef = this.matDialog.open(ConfirmDeleteSiteDialogComponent, {
+
+    const dialogRef = this.matDialog.open(DialogConfirmComponent, {
       data: {
-        site: site
+        titre: 'Confirmation suppression',
+        libConfirmation: `Souhaitez vous supprimer le site "${site?.Libelle}" ?`,
+        libBouton: 'Supprimer'
       }
     });
-
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         this.deleteSite(site.Id);
       }
     });
   }
-}
-
-@Component({
-  selector: 'confirm-delete-dialog',
-  templateUrl: './dialogs/confirm-delete-site-dialog.component.html',
-})
-export class ConfirmDeleteSiteDialogComponent {
-  constructor(
-    public dialogRef: MatDialogRef<ConfirmDeleteSiteDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: DialogData) { }
-}
-
-export interface DialogData {
-  site: Site;
 }

--- a/frontend/src/app/components/utilisateur/dialogs/confirm-delete-dialog.component.html
+++ b/frontend/src/app/components/utilisateur/dialogs/confirm-delete-dialog.component.html
@@ -1,8 +1,0 @@
-<h1 mat-dialog-title>Confirmation</h1>
-<mat-dialog-content class="mat-typography">
-  Souhaitez vous supprimer l'utilisateur "{{data?.utilisateur?.Nom}} {{data?.utilisateur?.Prenom}}" ?
-</mat-dialog-content>
-<mat-dialog-actions align="end">
-  <button mat-raised-button color="primary" type="button" [mat-dialog-close]="true" cdkFocusInitial>Supprimer</button>
-  <button mat-raised-button color="accent" type="button" mat-dialog-close>Annuler</button>
-</mat-dialog-actions>

--- a/frontend/src/app/components/utilisateur/utilisateur-list.component.html
+++ b/frontend/src/app/components/utilisateur/utilisateur-list.component.html
@@ -75,7 +75,7 @@
           <td mat-cell *matCellDef="let utilisateur">
             <div class="mat-button-list-container">
               <ng-template [ngIf]="connectedUser && connectedUser.hasPermissionByCodeName('utilisateur_archive')">
-                <button class="button-list" mat-stroked-button (click)="rendreActifObsoleteUtilisateur(utilisateur)"
+                <button class="button-list" mat-stroked-button (click)="ActiverDesactiverCompte(utilisateur)"
                   matTooltip="Passer l'utilisateur en Actif/Inactif" id="btnActifObsoleteUtilisateur">
                   <span class="mat-button-wrapper">
                     <span class="material-icons">hourglass_empty</span>


### PR DESCRIPTION
o Création d'un composant générique 'DialogConfirmComponent'
o Les composants ConfirmeDeleteDialog des sites & des utilisateurs ont été remplacé par celui générique
o Il est désormais possible d'activer / désactiver un utilisateur